### PR TITLE
state周り見直し

### DIFF
--- a/src/pages/results/[salmonId]/index.vue
+++ b/src/pages/results/[salmonId]/index.vue
@@ -10,7 +10,6 @@ const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
 const {
   pending,
-  data,
-} = await useFetch<CoopResultResponse>(`${runtimeConfig.public.apiUrlBase}v1/results/${route.params.salmonId}`)
-const result = data.value
+  data: result,
+} = useFetch<CoopResultResponse>(`${runtimeConfig.public.apiUrlBase}v1/results/${route.params.salmonId}`)
 </script>


### PR DESCRIPTION
## やりたいこと

state周りいい感じに修正

- 一覧画面
  - API呼ぶ実装は1箇所にまとめた
  - ブラウザバックや画面リロードしても変な感じにならないようにした
-  詳細画面
    - await周り使わないようにする

## 未対応事項

eslintを入れようとしているとのことで、一旦静的解析等は行ってません